### PR TITLE
Increase jaero instance limit to 25

### DIFF
--- a/rootfs/etc/cont-init.d/50-create-jaero-config
+++ b/rootfs/etc/cont-init.d/50-create-jaero-config
@@ -10,8 +10,8 @@ if ! [[ -d ${JAERO_HOME} ]]; then
     mkdir -p ${JAERO_HOME}/
 fi
 
-if [[ "${NUMBER_OF_SDRX_TOPICS}" -gt 20 ]]; then
-    echo "Please enter a SDRX topic number less than 21"
+if [[ "${NUMBER_OF_SDRX_TOPICS}" -gt 25 ]]; then
+    echo "Please enter a SDRX topic number less than 26"
     exit 1
 fi
 


### PR DESCRIPTION
This change will increase the limit from 20 to 25 instances of Jaero.

The sole reason I want this change is because my Inmarsat active patch antenna is capable of receiving both Inmarsat 98W and 54W at the same time.

Together, they have 17 600bps streams, 1 1200 bps stream, and 4 10500 bps streams. That's 23, which is more than the existing limit of 20.